### PR TITLE
Fix Title screen patch of FE7J

### DIFF
--- a/FEBuilderGBA/bin/Debug/config/patch2/FE7J/OPLOGO/PATCH_OPLOGO Sword.txt
+++ b/FEBuilderGBA/bin/Debug/config/patch2/FE7J/OPLOGO/PATCH_OPLOGO Sword.txt
@@ -8,7 +8,7 @@ TAG=#IMAGE
 
 //幅と高さ
 WIDTH=256
-HEIGHT=112
+HEIGHT=256
 //利用パレット数
 PALETTE=1
 


### PR DESCRIPTION
If the height is set to be 112, the exported image is cropped and does not include a part of the title logo.
I think the height should be 256, like the counterpart patch for FE7U, to include the rest of the title logo.