### PR TITLE
Add extra newline to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The editor supports
  * FE6 (The Binding Blade)
  * FE7J/FE7U (The Blazing Blade)
  * FE8J/FE8U (The Sacred Stones)
+
 Essentially, both Japanese and North American releases of all games (with the exception of FE6 being Japan-only) are supported.
 
 Starting from the main screen, FEBuilder supports a wide range of functions from image displaying, importing and export of most data, map remodeling, table editing, community patch management, music insertion, and much more. 


### PR DESCRIPTION
This list was missing a newline, which caused the markdown to display incorrectly:
![image](https://user-images.githubusercontent.com/14899090/210457709-ecc5251d-2f5e-41ab-bd11-95c9d8a3d6ab.png)

Now the message at the end is properly shown on a new line rather than being part of the list:
![image](https://user-images.githubusercontent.com/14899090/210457783-d7a773de-5318-4da6-a619-1e66d729e496.png)
